### PR TITLE
Update Mycroft AI listing

### DIFF
--- a/ethicalhq.csv
+++ b/ethicalhq.csv
@@ -314,8 +314,7 @@ Mumla,https://mumla-app.gitlab.io/,"A low latency, high quality voice conference
 Music Player Daemon,https://musicpd.org/,"Flexible, powerful, server-side application for playing music.",Streaming services 
 MyBB,https://mybb.com/,Free and open-source forum software.,Hangouts
 myclimate,https://myclimate.org/,Calculate and compensate for your emissions.,Organisations
-Mycroft-Android,https://github.com/MycroftAI/Mycroft-Android,The open and private voice assistant.,Assistant
-Mycroft-Android,https://mycroft.ai/,The open and private voice assistant.,Assistant
+Mycroft AI,https://mycroft.ai/,The open and private voice assistant.,Assistant
 MyHikes,https://myhikes.org/,Independent platform for hikers and backpackers to share and explore trails.,Maps
 Nebulo,https://git.frostnerd.com/PublicAndroidApps/smokescreen/-/blob/master/README.md,"Free, open-source, non-root and small sized DNS changer for Android utilizing dns-over-https and dns-over-tls to bring privacy and security to your phone.",Server
 Neibo,https://neibo.be/#,Belgium-based phone cooperative.,Smartphones


### PR DESCRIPTION
The Mycroft-Android project is pre-alpha and community-led so has no definitive timeline on a first release. As such it's not yet usable by anyone but Android developers.
Removed the link for that and updated the name for Mycroft AI.